### PR TITLE
fix:Added curl_cffi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,4 +42,4 @@ tenacity
 uv
 uvloop
 xattr
-yt-dlp[default]
+yt-dlp[default,curl-cffi]


### PR DESCRIPTION
- Solving HTTP Error 403
- Yt-dlp recommend this lib

## Summary by Sourcery

Bug Fixes:
- Resolve HTTP Error 403 by installing yt-dlp with the curl-cffi extra.