### PR TITLE
Update

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           heroku_api_key: ${{inputs.HEROKU_API_KEY}}
           heroku_app_name: ${{inputs.HEROKU_APP_NAME}}
           heroku_email: ${{inputs.HEROKU_EMAIL}}
-          team: ${{ inputs.HK_TEAM_NAME != '' && format('team={0}', inputs.HK_TEAM_NAME) || '' }}
+          team: ${{inputs.HK_TEAM_NAME}
           usedocker: true
           docker_heroku_process_type: web
           stack: "container"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           heroku_api_key: ${{inputs.HEROKU_API_KEY}}
           heroku_app_name: ${{inputs.HEROKU_APP_NAME}}
           heroku_email: ${{inputs.HEROKU_EMAIL}}
-          team: ${{inputs.HK_TEAM_NAME}
+          team: ${{ inputs.HK_TEAM_NAME }}
           usedocker: true
           docker_heroku_process_type: web
           stack: "container"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use the HK_TEAM_NAME input directly in the Heroku deployment workflow.