### PR TITLE
fix Issue with LOG_CHAT_ID

### DIFF
--- a/bot/core/torrent_manager.py
+++ b/bot/core/torrent_manager.py
@@ -1,5 +1,5 @@
 import contextlib
-from asyncio import TimeoutError, gather
+from asyncio import gather
 from inspect import iscoroutinefunction
 from pathlib import Path
 

--- a/bot/helper/listeners/aria2_listener.py
+++ b/bot/helper/listeners/aria2_listener.py
@@ -1,5 +1,5 @@
 import contextlib
-from asyncio import TimeoutError, sleep
+from asyncio import sleep
 from time import time
 
 from aiofiles.os import path as aiopath

--- a/bot/helper/listeners/direct_listener.py
+++ b/bot/helper/listeners/direct_listener.py
@@ -1,4 +1,4 @@
-from asyncio import TimeoutError, sleep
+from asyncio import sleep
 
 from aiohttp.client_exceptions import ClientError
 

--- a/bot/helper/listeners/qbit_listener.py
+++ b/bot/helper/listeners/qbit_listener.py
@@ -1,5 +1,5 @@
 import contextlib
-from asyncio import TimeoutError, sleep
+from asyncio import sleep
 from time import time
 
 from aiofiles.os import path as aiopath

--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -395,7 +395,7 @@ class TaskListener(TaskConfig):
                         )
                         if Config.LOG_CHAT_ID:
                             await send_message(
-                                Config.LOG_CHAT_ID,
+                                int(Config.LOG_CHAT_ID),
                                 f"{msg}<blockquote expandable>{fmsg}</blockquote>",
                             )
                         await sleep(1)
@@ -407,7 +407,7 @@ class TaskListener(TaskConfig):
                     )
                     if Config.LOG_CHAT_ID:
                         await send_message(
-                            Config.LOG_CHAT_ID,
+                            int(Config.LOG_CHAT_ID),
                             f"{msg}<blockquote expandable>{fmsg}</blockquote>",
                         )
                 await send_message(self.message, done_msg)
@@ -450,7 +450,7 @@ class TaskListener(TaskConfig):
             msg += f"\n\n<b>cc: </b>{self.tag}"
             await send_message(self.user_id, msg, button)
             if Config.LOG_CHAT_ID:
-                await send_message(Config.LOG_CHAT_ID, msg, button)
+                await send_message(int(Config.LOG_CHAT_ID), msg, button)
             await send_message(self.message, done_msg)
         if self.seed:
             await clean_target(self.up_dir)

--- a/bot/helper/mirror_leech_utils/download_utils/aria2_download.py
+++ b/bot/helper/mirror_leech_utils/download_utils/aria2_download.py
@@ -1,4 +1,3 @@
-from asyncio import TimeoutError
 from base64 import b64encode
 
 from aiofiles import open as aiopen

--- a/bot/helper/mirror_leech_utils/download_utils/qbit_download.py
+++ b/bot/helper/mirror_leech_utils/download_utils/qbit_download.py
@@ -1,4 +1,4 @@
-from asyncio import TimeoutError, sleep
+from asyncio import sleep
 
 from aiofiles import open as aiopen
 from aiofiles.os import path as aiopath


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the issue with LOG_CHAT_ID by ensuring it is converted to an integer before being used in send_message calls.