### PR TITLE
Minor update 🙂

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,39 +60,6 @@ We welcome contributions! Whether it's bug fixes, feature enhancements, or gener
 
 ---
 
-# Aeon-MLTB Docker Build Guide
-
-## Usage
-
-1. **Run the Workflow**  
-   - Go to the **Actions** tab in your repository.
-   - Select **Docker.io** workflow.
-   - Click **Run workflow** and provide:
-     - **Docker Hub Username**
-     - **Docker Hub Password**
-     - **Docker Image Name**
-
-2. **Result**  
-   Your Docker image will be available at:  
-   `docker.io/<username>/<image_name>:latest`.
-
-## Inputs
-
-| Input        | Description                        |
-|--------------|------------------------------------|
-| `username`   | Your Docker Hub username           |
-| `password`   | Your Docker Hub password           |
-| `image_name` | Name of the Docker image to build  |
-
-## Notes
-
-- **Platforms**: Builds for `linux/amd64` and `linux/arm64`.
-- **Authentication**: Credentials are securely handled via inputs.
-
-## Support
-
-For issues, join here https://t.me/AeonDiscussion.
-
 ## License
 
 This project is licensed under the MIT License. Refer to the [LICENSE](LICENSE) file for details.

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -966,7 +966,7 @@ class TaskConfig:
         except Exception:
             await send_message(
                 self.message,
-                "Reply to text file or to telegram message that have links seperated by new line!",
+                "Reply to text file or to telegram message that have links separated by new line!",
             )
 
     async def proceed_extract(self, dl_path, gid):

--- a/bot/helper/ext_utils/help_messages.py
+++ b/bot/helper/ext_utils/help_messages.py
@@ -638,7 +638,7 @@ Timeout: 60 sec""",
     "GDRIVE_ID": "Send Gdrive ID. If you want to use your token.pickle edit using owner/user token from usetting or add mtp: before the id. Example: mtp:F435RGGRDXXXXXX . Timeout: 60 sec",
     "INDEX_URL": "Send Index URL. Timeout: 60 sec",
     "UPLOAD_PATHS": "Send Dict of keys that have path values. Example: {'path 1': 'remote:rclonefolder', 'path 2': 'gdrive1 id', 'path 3': 'tg chat id', 'path 4': 'mrcc:remote:', 'path 5': b:@username} . Timeout: 60 sec",
-    "EXCLUDED_EXTENSIONS": "Send exluded extenions seperated by space without dot at beginning. Timeout: 60 sec",
+    "EXCLUDED_EXTENSIONS": "Send exluded extenions separated by space without dot at beginning. Timeout: 60 sec",
     "NAME_SUBSTITUTE": r"""Word Subtitions. You can add pattern instead of normal text. Timeout: 60 sec
 NOTE: You must add \ before any character, those are the characters: \^$.|?*+()[]{}-
 Example: script/code/s | mirror/leech | tea/ /s | clone | cpu/ | \[mltb\]/mltb | \\text\\/text/s

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -265,7 +265,7 @@ async def get_buttons(key=None, edit_type=None, page=0, user_id=None):
             buttons.data_button("Default", f"botset resetnzb {key}")
             buttons.data_button("Empty String", f"botset emptynzb {key}")
             buttons.data_button("Close", "botset close")
-            msg = f"Send a valid value for {key}. Current value is '{nzb_options[key]}'.\nIf the value is list then seperate them by space or ,\nExample: .exe,info or .exe .info\nTimeout: 60 sec"
+            msg = f"Send a valid value for {key}. Current value is '{nzb_options[key]}'.\nIf the value is list then separate them by space or ,\nExample: .exe,info or .exe .info\nTimeout: 60 sec"
         elif edit_type.startswith("nzbsevar"):
             index = 0 if key == "newser" else int(edit_type.replace("nzbsevar", ""))
             buttons.data_button("Back", f"botset nzbser{index}")


### PR DESCRIPTION
This pull request includes several changes, primarily focused on improving documentation and fixing typographical errors in the codebase. The most significant changes include the removal of a Docker build guide from the `README.md` file and corrections to spelling errors in user-facing messages across various files.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-L95): Removed the Docker build guide section, including usage instructions, inputs, notes, and support information. This simplifies the README to focus on licensing information.

### Typographical fixes:
* [`bot/helper/common.py`](diffhunk://#diff-4d60911dfebea92f6a8d42241e2c15185820e7efb163913dd23d2327cf56dd0dL969-R969): Corrected the spelling of "seperated" to "separated" in an error message displayed to users.
* [`bot/helper/ext_utils/help_messages.py`](diffhunk://#diff-5f8738bd47ba3bb2f99b452dd03f8e76dfc7f6637428e96c324743cdff8060c4L641-R641): Fixed the spelling of "seperated" to "separated" in the description for excluded extensions.
* [`bot/modules/bot_settings.py`](diffhunk://#diff-118581045cd17ab147dc77e96257b0fddb0a3ce2971eca1a15a9f832de01ea3fL268-R268): Updated a user-facing message to fix the spelling of "seperate" to "separate" in instructions for providing a valid value.

## Summary by Sourcery

Remove Docker build guide from README and fix spelling errors in user-facing messages

Bug Fixes:
- Corrected spelling of 'separated' in multiple user-facing error messages and instructions across different files

Documentation:
- Removed the Docker build guide section from README.md, simplifying the document to focus on licensing information