### PR TITLE
Update message_utils.py

### DIFF
--- a/bot/helper/telegram_helper/message_utils.py
+++ b/bot/helper/telegram_helper/message_utils.py
@@ -84,32 +84,32 @@ async def edit_message(
     markdown=False,
     block=True,
 ):
-    parse_mode = enums.ParseMode.MARKDOWN if markdown else enums.ParseMode.HTML
+    # parse_mode = enums.ParseMode.MARKDOWN if markdown else enums.ParseMode.HTML
     try:
         if message.media:
             if photo:
                 return await message.edit_media(
                     InputMediaPhoto(photo, text),
                     reply_markup=buttons,
-                    parse_mode=parse_mode,
+                    # parse_mode=parse_mode,
                 )
             return await message.edit_caption(
                 caption=text,
                 reply_markup=buttons,
-                parse_mode=parse_mode,
+                # parse_mode=parse_mode,
             )
         await message.edit(
             text=text,
             disable_web_page_preview=True,
             reply_markup=buttons,
-            parse_mode=parse_mode,
+            # parse_mode=parse_mode,
         )
     except FloodWait as f:
         LOGGER.warning(str(f))
         if not block:
             return message
         await sleep(f.value * 1.2)
-        return await edit_message(message, text, buttons, photo, markdown)
+        return await edit_message(message, text, buttons, photo)
     except (MessageNotModified, MessageEmpty):
         pass
     except Exception as e:


### PR DESCRIPTION
## Summary by Sourcery

Simplify the edit_message helper by disabling its parse_mode support and adjusting its retry logic

Bug Fixes:
- Remove parse_mode arguments to avoid unsupported parameter errors during message edits

Enhancements:
- Comment out parse_mode selection and usage in edit_message
- Drop the markdown flag from the recursive retry call to prevent incorrect argument passing