### PR TITLE
fix: remove parse_mode arguments to avoid unsupported parameter error.

### DIFF
--- a/bot/helper/telegram_helper/message_utils.py
+++ b/bot/helper/telegram_helper/message_utils.py
@@ -84,32 +84,32 @@ async def edit_message(
     markdown=False,
     block=True,
 ):
-    parse_mode = enums.ParseMode.MARKDOWN if markdown else enums.ParseMode.HTML
+    # parse_mode = enums.ParseMode.MARKDOWN if markdown else enums.ParseMode.HTML
     try:
         if message.media:
             if photo:
                 return await message.edit_media(
                     InputMediaPhoto(photo, text),
                     reply_markup=buttons,
-                    parse_mode=parse_mode,
+                    # parse_mode=parse_mode,
                 )
             return await message.edit_caption(
                 caption=text,
                 reply_markup=buttons,
-                parse_mode=parse_mode,
+                # parse_mode=parse_mode,
             )
         await message.edit(
             text=text,
             disable_web_page_preview=True,
             reply_markup=buttons,
-            parse_mode=parse_mode,
+            # parse_mode=parse_mode,
         )
     except FloodWait as f:
         LOGGER.warning(str(f))
         if not block:
             return message
         await sleep(f.value * 1.2)
-        return await edit_message(message, text, buttons, photo, markdown)
+        return await edit_message(message, text, buttons, photo)
     except (MessageNotModified, MessageEmpty):
         pass
     except Exception as e:


### PR DESCRIPTION
…s during message edits.

## Summary by Sourcery

Remove deprecated parse_mode parameters from message editing functions to prevent unsupported-parameter errors and update the recursive edit call signature accordingly.

Bug Fixes:
- Comment out parse_mode assignment and argument usage in edit_media, edit_caption, and edit calls to avoid unsupported parameter errors.
- Adjust the recursive edit_message invocation to drop the markdown argument.